### PR TITLE
Support Accumulo PluginEnvironment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <version.accumulo>2.1.1</version.accumulo>
         <version.hadoop>3.3.4</version.hadoop>
+        <version.mockito>2.28.2</version.mockito>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -61,6 +62,11 @@
                 <artifactId>hadoop-common</artifactId>
                 <version>${version.hadoop}</version>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.mockito}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -71,6 +77,10 @@
         <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-server-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
     <pluginRepositories>

--- a/src/main/java/datawave/accumulo/inmemory/InMemoryScannerBase.java
+++ b/src/main/java/datawave/accumulo/inmemory/InMemoryScannerBase.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
+import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.client.SampleNotPresentException;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.clientImpl.ScannerOptions;
@@ -81,6 +82,11 @@ public class InMemoryScannerBase extends ScannerOptions {
         @Override
         public AccumuloConfiguration getConfig() {
             return DefaultConfiguration.getInstance();
+        }
+        
+        @Override
+        public PluginEnvironment getPluginEnv() {
+            return MockPluginEnvironment.newInstance(getConfig());
         }
         
         @Override

--- a/src/main/java/datawave/accumulo/inmemory/MockPluginEnvironment.java
+++ b/src/main/java/datawave/accumulo/inmemory/MockPluginEnvironment.java
@@ -1,0 +1,28 @@
+package datawave.accumulo.inmemory;
+
+import org.apache.accumulo.core.client.PluginEnvironment;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.util.ConfigurationImpl;
+import org.mockito.Mockito;
+
+/**
+ * A mock of a {@link org.apache.accumulo.core.client.PluginEnvironment} using mockito.
+ */
+public final class MockPluginEnvironment {
+    private MockPluginEnvironment() {
+        // Utility only, do not instantiate
+    }
+    
+    /**
+     * Creates a new mock PluginEnvironment.
+     * 
+     * @param conf
+     *            The accumulo configuration
+     * @return A plugin environment
+     */
+    public static PluginEnvironment newInstance(AccumuloConfiguration conf) {
+        PluginEnvironment pluginEnv = Mockito.mock(PluginEnvironment.class);
+        Mockito.when(pluginEnv.getConfiguration()).thenReturn(new ConfigurationImpl(conf));
+        return pluginEnv;
+    }
+}


### PR DESCRIPTION
In Accumulo 2.x, the PluginEnvironment is the prescribed API for fetching configs during iterators. This updates our mock Accumulo to support that method call.