### PR TITLE
Only add iterators to the chain if a top key exists

### DIFF
--- a/src/main/java/datawave/accumulo/inmemory/InMemoryBatchScanner.java
+++ b/src/main/java/datawave/accumulo/inmemory/InMemoryBatchScanner.java
@@ -73,7 +73,9 @@ public class InMemoryBatchScanner extends InMemoryScannerBase implements BatchSc
             try {
                 i = createFilter(i);
                 i.seek(range, createColumnBSS(fetchedColumns), !fetchedColumns.isEmpty());
-                chain.addIterator(new IteratorAdapter(i));
+                if (i.hasTop()) {
+                    chain.addIterator(new IteratorAdapter(i));
+                }
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Certain test cases in the main datawave repo that utilize the RebuildingScannerTestHelper will throw null pointer exceptions when an iterator with no top key is added to the chain.